### PR TITLE
migration to Java11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /starparse-client/starparse.log
 /starparse-client/starparse.xml
 /starparse-client/icons
+.idea/
+starparse-client/starparse-client.iml
+starparse-shared/starparse-shared.iml
+starparse.iml
+starparse.log
+starparse.xml

--- a/starparse-client/pom.xml
+++ b/starparse-client/pom.xml
@@ -15,7 +15,7 @@
 
 	<packaging>jar</packaging>
 	<properties>
-		<java-version>1.8</java-version>
+		<java-version>11</java-version>
 		<org.springframework-version>4.0.0.RELEASE</org.springframework-version>
 		<org.slf4j-version>1.6.1</org.slf4j-version>
 	</properties>
@@ -131,6 +131,29 @@
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna-platform</artifactId>
 			<version>4.1.0</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.15</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-media</artifactId>
+			<version>11</version>
 		</dependency>
 
 	</dependencies>

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/Config.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/Config.java
@@ -3,6 +3,7 @@ package com.ixale.starparse.gui;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -346,8 +347,8 @@ public class Config implements Serializable {
 			return null;
 		}
 		try {
-			return new String(new sun.misc.BASE64Decoder().decodeBuffer(this.parselyPasswordEnc));
-		} catch (IOException e) {
+			return new String(Base64.getDecoder().decode(this.parselyPasswordEnc));
+		} catch (Exception e) {
 			return null;
 		}
 	}
@@ -358,7 +359,7 @@ public class Config implements Serializable {
 			this.parselyPasswordEnc = null;
 			return;
 		}
-		this.parselyPasswordEnc = new sun.misc.BASE64Encoder().encode(parselyPassword.getBytes());
+		this.parselyPasswordEnc = new String(Base64.getEncoder().encode(parselyPassword.getBytes()));
 	}
 
 	public String getParselyEndpoint() {

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/Main.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/Main.java
@@ -1,0 +1,7 @@
+package com.ixale.starparse.gui;
+
+public class Main {
+    public static void main(String[] args) {
+        StarparseApp.main(args);
+    }
+}

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/StarparseAppFactory.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/StarparseAppFactory.java
@@ -162,7 +162,7 @@ public class StarparseAppFactory
 		{
 			fxmlStream = getClass().getResourceAsStream(fxmlFile);
 
-			FXMLLoader loader = new FXMLLoader(Class.class.getResource("/fxml/"));
+			FXMLLoader loader = new FXMLLoader(this.getClass().getResource("/fxml/"));
 			loader.load(fxmlStream);
 			return (T) loader.getController();
 		} catch (IOException e)

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/Win32Utils.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/Win32Utils.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.swing.KeyStroke;
 
+import javafx.stage.Window;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,8 +124,13 @@ public class Win32Utils {
 		}
 
 		try {
-			@SuppressWarnings({"deprecation"})
-			final TKStage tkStage = stage.impl_getPeer();
+			//@SuppressWarnings({"deprecation"})
+			//final TKStage tkStage = stage.impl_getPeer();
+
+			Method getPeer = Window.class.getDeclaredMethod("getPeer");
+			getPeer.setAccessible(true);
+			final TKStage tkStage = (TKStage) getPeer.invoke(stage);
+
 			if (tkStage == null) {
 				// does not exists (yet)
 				return null;

--- a/starparse-shared/pom.xml
+++ b/starparse-shared/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>jar</packaging>
  
 	<properties>
-		<java-version>1.7</java-version>
+		<java-version>11</java-version>
 	</properties>
 
 	<dependencies>
@@ -44,7 +44,6 @@
 					<source>${java-version}</source>
 					<target>${java-version}</target>
 				</configuration>
-				<version>3.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/starparse-shared/src/main/java/com/ixale/starparse/domain/RaidGroup.java
+++ b/starparse-shared/src/main/java/com/ixale/starparse/domain/RaidGroup.java
@@ -2,6 +2,8 @@ package com.ixale.starparse.domain;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Base64;
+
 
 public class RaidGroup implements Serializable {
 
@@ -25,16 +27,17 @@ public class RaidGroup implements Serializable {
 
 	@SuppressWarnings("restriction")
 	public String getClientPassword() {
+
 		try {
-			return new String(new sun.misc.BASE64Decoder().decodeBuffer(this.clientPasswordEnc));
-		} catch (IOException e) {
+			return new String(Base64.getDecoder().decode(this.clientPasswordEnc));
+		} catch (Exception e) {
 			return null;
 		}
 	}
 
 	@SuppressWarnings("restriction")
 	public void setClientPassword(String clientPassword) {
-		this.clientPasswordEnc = new sun.misc.BASE64Encoder().encode(clientPassword.getBytes());
+		this.clientPasswordEnc = new String(Base64.getEncoder().encode(clientPassword.getBytes()));
 	}
 
 	@SuppressWarnings("restriction")
@@ -43,15 +46,15 @@ public class RaidGroup implements Serializable {
 			return null;
 		}
 		try {
-			return new String(new sun.misc.BASE64Decoder().decodeBuffer(this.adminPasswordEnc));
-		} catch (IOException e) {
+			return new String(Base64.getDecoder().decode(this.adminPasswordEnc));
+		} catch (Exception e) {
 			return null;
 		}
 	}
 
 	@SuppressWarnings("restriction")
 	public void setAdminPassword(String adminPassword) {
-		this.adminPasswordEnc = new sun.misc.BASE64Encoder().encode(adminPassword.getBytes());
+		this.adminPasswordEnc = new String(Base64.getEncoder().encode(adminPassword.getBytes()));
 	}
 
 	public String toString() {


### PR DESCRIPTION
Java 8 public support ended in 2019. 

Note that some javafx packages that were included in jdk8 were removed in jdk11. So I re-added these via maven.

Additionally Java 9 added the notion of a modular JDK through its "jigsaw project". I did not dig a lot into it so far. Looks interesting since so far as I understand, its goal was to reduce jre size by only including parts of the runtime that are really necessary. It could help having a smaller bundle release. But by default the whole thing stays monolithic

Another point is that due to that modular stuff, I had to create a new Main class since JavaFx refuses to start in a non modular environment if the main class is a javafx class, so what I did is kind or a workaround