### PR TITLE
Damage taken popup jdk8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@
 /starparse-client/starparse.log
 /starparse-client/starparse.xml
 /starparse-client/icons
+.idea/
+starparse-client/starparse-client.iml
+starparse-shared/starparse-shared.iml
+starparse.iml
+starparse.log
+starparse.xml
+starparse-attacks.xml
+starparse-timers.xml

--- a/starparse-client/src/main/java/com/ixale/starparse/domain/ConfigPopoutDefault.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/domain/ConfigPopoutDefault.java
@@ -24,7 +24,7 @@ public class ConfigPopoutDefault implements Serializable {
 
 	private Boolean mouseTransparent, timersCenter, solid;
 
-	private Integer timersFractions;
+	private Integer timersFractions, dtDelay1, dtDelay2;
 
 	private Color get(String c, Color d) {
 		if (c == null) {
@@ -115,5 +115,21 @@ public class ConfigPopoutDefault implements Serializable {
 
 	public void setSolid(Boolean solid) {
 		this.solid = solid;
+	}
+
+	public Integer getDtDelay1() {
+		return dtDelay1;
+	}
+
+	public void setDtDelay1(Integer dtDelay1) {
+		this.dtDelay1 = dtDelay1;
+	}
+
+	public Integer getDtDelay2() {
+		return dtDelay2;
+	}
+
+	public void setDtDelay2(Integer dtDelay2) {
+		this.dtDelay2 = dtDelay2;
 	}
 }

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/StarparseAppFactory.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/StarparseAppFactory.java
@@ -3,6 +3,7 @@ package com.ixale.starparse.gui;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.ixale.starparse.gui.popout.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
@@ -18,15 +19,6 @@ import com.ixale.starparse.gui.main.HealingTakenPresenter;
 import com.ixale.starparse.gui.main.MainPresenter;
 import com.ixale.starparse.gui.main.OverviewPresenter;
 import com.ixale.starparse.gui.main.RaidPresenter;
-import com.ixale.starparse.gui.popout.ChallengesPopoutPresenter;
-import com.ixale.starparse.gui.popout.HotsPopoutPresenter;
-import com.ixale.starparse.gui.popout.PersonalStatsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidDpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidHpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidNotesPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidTpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.TimersCenterPopoutPresenter;
-import com.ixale.starparse.gui.popout.TimersPopoutPresenter;
 
 import javafx.fxml.FXMLLoader;
 
@@ -98,6 +90,12 @@ public class StarparseAppFactory
 	public PersonalStatsPopoutPresenter personalStatsPopoutPresenter()
 	{
 		return loadPresenter("/fxml/PersonalStatsPopout.fxml");
+	}
+
+	@Bean
+	public DamageTakenPopoutPresenter damageTakenPopoutPresenter()
+	{
+		return loadPresenter("/fxml/DamageTakenPopout.fxml");
 	}
 
 	@Bean

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/dialog/SettingsDialogPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/dialog/SettingsDialogPresenter.java
@@ -103,14 +103,14 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 		raidGroupNameField, raidGroupClientPasswordField, raidGroupAdminPasswordField,
 		raidPullSec, raidPullHotkey, raidBreakMin,
 		raidDamageOpacityText, raidHealingOpacityText, raidThreatOpacityText,
-		raidChallengesOpacityText, timersOpacityText, timersFractions, personalOpacityText, lockOverlaysHotkey,
+		raidChallengesOpacityText, timersOpacityText, timersFractions, personalOpacityText, damageTakenOpacityText, lockOverlaysHotkey,
 		guildField, parselyLoginField, parselyPasswordField,
 		timerName, timerSourceName, timerTargetName, timerAbilityName, timerEffectName,
 		timerDuration, timerRepeat, timerSoundOffset, timerCountdownCount;
 
 	@FXML
 	private Slider raidDamageOpacitySlider, raidHealingOpacitySlider, raidThreatOpacitySlider,
-		raidChallengesOpacitySlider, timersOpacitySlider, personalOpacitySlider, timerSoundVolume, timerCountdownVolume;
+		raidChallengesOpacitySlider, timersOpacitySlider, personalOpacitySlider, damageTakenOpacitySlider, timerSoundVolume, timerCountdownVolume;
 
 	@FXML
 	private Button raidGroupJoinButton, raidGroupCreateButton, timersCenterMoveButton, overlaysResetButton,
@@ -118,7 +118,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 
 	@FXML
 	private CheckBox timeSyncEnabledButton, serverStoreEnabledButton,
-		raidDamageBars, raidHealingBars, raidThreatBars, raidChallengesBars, timersBars, personalBars, timersCenter, popoutSolid,
+		raidDamageBars, raidHealingBars, raidThreatBars, raidChallengesBars, timersBars, personalBars, damageTakenBars, timersCenter, popoutSolid,
 		timerDisplay, timerPlaySound, timersIgnoreRepeated, timerPlayCountdown;
 
 	@FXML
@@ -131,7 +131,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 
 	@FXML
 	private ChoiceBox<String> timezoneList, serverList,
-		raidHealingMode, personalMode,
+		raidHealingMode, personalMode, damageTakenMode,
 		timerTrigger, timerTriggerTimer, timerBoss, timerCancel;
 
 	@FXML
@@ -190,6 +190,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			double raidChallengesOpacity, boolean raidChallengesBars,
 			double timersOpacity, boolean timersBars,
 			double personalOpacity, boolean personalBars, String personalMode,
+			double damageTakenOpacity, boolean damageTakenBars, String damageTakenMode,
 			//
 			boolean timersCenter, Double timersCenterX, Double timersCenterY,
 			Integer fractions,
@@ -980,7 +981,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 
 	private class OverlaysSettings extends BaseSettings {
 
-		private final List<Mode> raidHealingModes = new ArrayList<>(), personalModes = new ArrayList<>();
+		private final List<Mode> raidHealingModes = new ArrayList<>(), personalModes = new ArrayList<>(), damageTakenModes = new ArrayList<>();
 
 		private final Tooltip timersAnchor = new Tooltip();
 
@@ -1000,6 +1001,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			bindSlider(raidChallengesOpacitySlider, raidChallengesOpacityText);
 			bindSlider(timersOpacitySlider, timersOpacityText);
 			bindSlider(personalOpacitySlider, personalOpacityText);
+			bindSlider(damageTakenOpacitySlider, damageTakenOpacityText);
 
 			bindPreview(raidDamageBars);
 			bindPreview(raidHealingBars);
@@ -1285,6 +1287,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			loadPopoutCurrent("Raid Challenges", raidChallengesOpacitySlider, raidChallengesOpacityText, raidChallengesBars, null, null);
 			loadPopoutCurrent("Timers", timersOpacitySlider, timersOpacityText, timersBars, null, null);
 			loadPopoutCurrent("Personal", personalOpacitySlider, personalOpacityText, personalBars, personalModes, personalMode);
+			loadPopoutCurrent("Damage Taken", damageTakenOpacitySlider, damageTakenOpacityText, damageTakenBars, damageTakenModes, damageTakenMode);
 
 			current.put(timersCenter, config.getCurrentCharacter().getPopout("Timers Center").isEnabled());
 			current.put(timersCenterMoveButton, new Double[]{
@@ -1388,9 +1391,11 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			savePopoutCurrent("Raid Challenges", raidChallengesOpacitySlider.getValue() / 100, raidChallengesBars.isSelected());
 			savePopoutCurrent("Timers", timersOpacitySlider.getValue() / 100, timersBars.isSelected());
 			savePopoutCurrent("Personal", personalOpacitySlider.getValue() / 100, personalBars.isSelected());
+			savePopoutCurrent("Damage Taken", damageTakenOpacitySlider.getValue() / 100, damageTakenBars.isSelected());
 
 			config.getCurrentCharacter().getPopout("Raid Healing").setMode(getMode(raidHealingMode, raidHealingModes));
 			config.getCurrentCharacter().getPopout("Personal").setMode(getMode(personalMode, personalModes));
+			config.getCurrentCharacter().getPopout("Damage Taken").setMode(getMode(damageTakenMode, damageTakenModes));
 
 			config.getCurrentCharacter().getPopout("Timers Center").setEnabled(timersCenter.isSelected());
 			if (timersCenterMoveButton.getUserData() != null) {
@@ -1459,6 +1464,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 					raidChallengesOpacitySlider.getValue() / 100, raidChallengesBars.isSelected(),
 					timersOpacitySlider.getValue() / 100, timersBars.isSelected(),
 					personalOpacitySlider.getValue() / 100, personalBars.isSelected(), getMode(personalMode, personalModes),
+					damageTakenOpacitySlider.getValue() / 100, damageTakenBars.isSelected(), getMode(damageTakenMode, damageTakenModes),
 					//
 					timersCenter.isSelected(),
 					timersCenterMoveButton.getUserData() != null ? ((Double[]) timersCenterMoveButton.getUserData())[0] : null,

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/dialog/SettingsDialogPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/dialog/SettingsDialogPresenter.java
@@ -106,7 +106,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 		raidChallengesOpacityText, timersOpacityText, timersFractions, personalOpacityText, damageTakenOpacityText, lockOverlaysHotkey,
 		guildField, parselyLoginField, parselyPasswordField,
 		timerName, timerSourceName, timerTargetName, timerAbilityName, timerEffectName,
-		timerDuration, timerRepeat, timerSoundOffset, timerCountdownCount;
+		timerDuration, timerRepeat, timerSoundOffset, timerCountdownCount, dtDelay1, dtDelay2;
 
 	@FXML
 	private Slider raidDamageOpacitySlider, raidHealingOpacitySlider, raidThreatOpacitySlider,
@@ -193,7 +193,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			double damageTakenOpacity, boolean damageTakenBars, String damageTakenMode,
 			//
 			boolean timersCenter, Double timersCenterX, Double timersCenterY,
-			Integer fractions,
+			Integer fractions, Integer dtDelay1, Integer dtDelay2,
 			boolean popoutSolid);
 
 		void onOverlaysReset(String characterName);
@@ -1030,38 +1030,9 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 				}
 			});
 
-			defaults.put(timersFractions, "");
-			validators.put(timersFractions, new Validator<TextField>() {
-				@Override
-				public boolean isValid(TextField c) {
-					if (c.getText() == null || c.getText().isEmpty()) {
-						return true;
-					}
-					try {
-						int x = Integer.parseInt(c.getText());
-						return x >= 1 && x <= 99;
-					} catch (NumberFormatException e) {
-						return false;
-					}
-				}
-			});
-			timersFractions.textProperty().addListener(new ChangeListener<String>() {
-				@Override
-				public void changed(ObservableValue<? extends String> obsVal, String oldVal, String newVal) {
-					if (newVal == null) {
-						return;
-					}
-					try {
-						if (!validate(timersFractions)) {
-							return;
-						}
-						fireSettingsUpdated();
-
-					} catch (Exception e) {
-
-					}
-				}
-			});
+			initializeNumericTextField(timersFractions, 1, 99);
+			initializeNumericTextField(dtDelay1, 2, 15);
+			initializeNumericTextField(dtDelay2, 3, 60);
 
 			timersCenterMoveButton.setDisable(true);
 			timersCenterMoveButton.setOnAction(new EventHandler<ActionEvent>() {
@@ -1170,6 +1141,41 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 
 			defaults.put(lockOverlaysHotkey, "");
 			validators.put(lockOverlaysHotkey, hotkeyValidator);
+		}
+
+		private void initializeNumericTextField(TextField textField, int minValue, int maxValue) {
+			defaults.put(textField, "");
+			validators.put(textField, new Validator<TextField>() {
+				@Override
+				public boolean isValid(TextField c) {
+					if (c.getText() == null || c.getText().isEmpty()) {
+						return true;
+					}
+					try {
+						int x = Integer.parseInt(c.getText());
+						return x >= minValue && x <= maxValue;
+					} catch (NumberFormatException e) {
+						return false;
+					}
+				}
+			});
+			textField.textProperty().addListener(new ChangeListener<String>() {
+				@Override
+				public void changed(ObservableValue<? extends String> obsVal, String oldVal, String newVal) {
+					if (newVal == null) {
+						return;
+					}
+					try {
+						if (!validate(textField)) {
+							return;
+						}
+						fireSettingsUpdated();
+
+					} catch (Exception e) {
+
+					}
+				}
+			});
 		}
 
 		private void bindSlider(final Slider slider, final TextField text) {
@@ -1295,11 +1301,9 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 					config.getCurrentCharacter().getPopout("Timers Center").getPositionY()
 			});
 
-			if (config.getPopoutDefault().getTimersFractions() != null) {
-				current.put(timersFractions, String.valueOf(config.getPopoutDefault().getTimersFractions()));
-			} else {
-				current.put(timersFractions, "");
-			}
+			putIfNotNull(timersFractions, config.getPopoutDefault().getTimersFractions());
+			putIfNotNull(dtDelay1, config.getPopoutDefault().getDtDelay1());
+			putIfNotNull(dtDelay2, config.getPopoutDefault().getDtDelay2());
 
 			current.put(lockOverlaysHotkey, config.getlockOverlaysHotkey() == null ? "" : config.getlockOverlaysHotkey());
 
@@ -1312,6 +1316,14 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 				overlaysResetButton.setVisible(false);
 			}
 			suppressEvents = false;
+		}
+
+		private void putIfNotNull(TextField textField, Integer integer) {
+			if (integer != null) {
+				current.put(textField, String.valueOf(integer));
+			} else {
+				current.put(textField, "");
+			}
 		}
 
 		private void loadPopoutCurrent(String name, Slider opacitySlider, TextField opacityText, CheckBox bars, final List<Mode> modes,
@@ -1412,6 +1424,8 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 			}
 
 			config.getPopoutDefault().setTimersFractions(getSafeInt(timersFractions));
+			config.getPopoutDefault().setDtDelay1(getSafeInt(dtDelay1));
+			config.getPopoutDefault().setDtDelay2(getSafeInt(dtDelay2));
 			config.getPopoutDefault().setSolid(popoutSolid.isSelected());
 
 			isDirty = false;
@@ -1469,7 +1483,7 @@ public class SettingsDialogPresenter extends BaseDialogPresenter {
 					timersCenter.isSelected(),
 					timersCenterMoveButton.getUserData() != null ? ((Double[]) timersCenterMoveButton.getUserData())[0] : null,
 					timersCenterMoveButton.getUserData() != null ? ((Double[]) timersCenterMoveButton.getUserData())[1] : null,
-					getSafeInt(timersFractions),
+					getSafeInt(timersFractions), getSafeInt(dtDelay1), getSafeInt(dtDelay2),
 					popoutSolid.isSelected());
 			}
 			isDirty = true;

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
@@ -346,7 +346,7 @@ public class MainPresenter implements Initializable {
 			final double personalOpacity, final boolean personalBars, final String personalMode,
 			final double damageTakenOpacity, final boolean damageTakenBars, final String damageTakenMode,
 			final boolean timersCenter, final Double timersCenterX, final Double timersCenterY,
-			final Integer fractions,
+			final Integer fractions,  final Integer dtDelay1, final Integer dtDelay2,
 			final boolean popoutSolid) {
 			// popout settings
 			for (final StatsPopout sp: popouts) {
@@ -396,6 +396,8 @@ public class MainPresenter implements Initializable {
 						sp.presenter.setOpacity(damageTakenOpacity);
 						sp.presenter.setBars(damageTakenBars);
 						sp.presenter.setMode(damageTakenMode);
+						((DamageTakenPopoutPresenter) sp.presenter).setDtDelay1(dtDelay1);
+						((DamageTakenPopoutPresenter) sp.presenter).setDtDelay2(dtDelay2);
 
 					} else if (sp.presenter instanceof RaidNotesPopoutPresenter) {
 						sp.presenter.setOpacity(personalOpacity); // TODO
@@ -1209,6 +1211,8 @@ public class MainPresenter implements Initializable {
 
 		timersPopoutPresenter.setTimersCenterControl(timersCenterPopoutPresenter);
 		timersPopoutPresenter.setFractions(config.getPopoutDefault().getTimersFractions());
+		damageTakenPopoutPresenter.setDtDelay1(config.getPopoutDefault().getDtDelay1());
+		damageTakenPopoutPresenter.setDtDelay2(config.getPopoutDefault().getDtDelay2());
 
 		raidPresenter.addRaidUpdateListener(raidDataListener);
 		raidPresenter.setRaidManager(raidManager);
@@ -1249,7 +1253,7 @@ public class MainPresenter implements Initializable {
 				final double personalOpacity, final boolean personalBars, final String personalMode,
 				final double damageTakenOpacity, final boolean damageTakenBars, final String damageTakenMode,
 				final boolean timersCenter, final Double timersCenterX, final Double timersCenterY,
-				final Integer fractions,
+				final Integer fractions, final Integer dtDelay1, final Integer dtDelay2,
 				final boolean popoutSolid) {
 				StatsPopout.setSettings(backgroundColor, textColor, damageColor, healingColor, threatColor, friendlyColor,
 					raidDamageOpacity, raidDamageBars,
@@ -1260,7 +1264,7 @@ public class MainPresenter implements Initializable {
 					personalOpacity, personalBars, personalMode,
 					damageTakenOpacity, damageTakenBars, damageTakenMode,
 					timersCenter, timersCenterX, timersCenterY,
-					fractions,
+					fractions, dtDelay1, dtDelay2,
 					popoutSolid);
 			}
 

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
@@ -14,6 +14,7 @@ import java.util.ResourceBundle;
 
 import javax.inject.Inject;
 
+import com.ixale.starparse.gui.popout.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,17 +34,6 @@ import com.ixale.starparse.gui.dialog.RaidNotesDialogPresenter;
 import com.ixale.starparse.gui.dialog.SettingsDialogPresenter;
 import com.ixale.starparse.gui.dialog.UploadParselyDialogPresenter;
 import com.ixale.starparse.gui.dialog.UploadParselyDialogPresenter.UploadParselyListener;
-import com.ixale.starparse.gui.popout.BasePopoutPresenter;
-import com.ixale.starparse.gui.popout.BaseRaidPopoutPresenter;
-import com.ixale.starparse.gui.popout.ChallengesPopoutPresenter;
-import com.ixale.starparse.gui.popout.HotsPopoutPresenter;
-import com.ixale.starparse.gui.popout.PersonalStatsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidDpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidHpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidNotesPopoutPresenter;
-import com.ixale.starparse.gui.popout.RaidTpsPopoutPresenter;
-import com.ixale.starparse.gui.popout.TimersCenterPopoutPresenter;
-import com.ixale.starparse.gui.popout.TimersPopoutPresenter;
 import com.ixale.starparse.gui.timeline.Timeline;
 import com.ixale.starparse.gui.timeline.TimelineListener;
 import com.ixale.starparse.log.LogWatcher;
@@ -142,7 +132,7 @@ public class MainPresenter implements Initializable {
 	@FXML
 	private MenuItem raidGroupsSettingsMenu, timersSettingsMenu;
 	@FXML
-	private CheckMenuItem timersPopoutMenu, timersCenterPopoutMenu, personalStatsPopoutMenu, challengesPopoutMenu,
+	private CheckMenuItem timersPopoutMenu, timersCenterPopoutMenu, personalStatsPopoutMenu, damageTakenPopoutMenu, challengesPopoutMenu,
 		raidDpsPopoutMenu, raidHpsPopoutMenu, raidTpsPopoutMenu, hotsPopoutMenu, raidNotesPopoutMenu, lockOverlaysMenu;
 
 	@Inject
@@ -173,6 +163,8 @@ public class MainPresenter implements Initializable {
 	private TimersCenterPopoutPresenter timersCenterPopoutPresenter;
 	@Inject
 	private PersonalStatsPopoutPresenter personalStatsPopoutPresenter;
+	@Inject
+	private DamageTakenPopoutPresenter damageTakenPopoutPresenter;
 	@Inject
 	private ChallengesPopoutPresenter challengesPopoutPresenter;
 	@Inject
@@ -1201,6 +1193,7 @@ public class MainPresenter implements Initializable {
 		StatsPopout.add(timersPopoutPresenter, timersPopoutMenu, config);
 		StatsPopout.add(timersCenterPopoutPresenter, timersCenterPopoutMenu, config);
 		StatsPopout.add(personalStatsPopoutPresenter, personalStatsPopoutMenu, config);
+		StatsPopout.add(damageTakenPopoutPresenter, damageTakenPopoutMenu, config);
 		StatsPopout.add(challengesPopoutPresenter, challengesPopoutMenu, config);
 		StatsPopout.add(raidDpsPopoutPresenter, raidDpsPopoutMenu, config);
 		StatsPopout.add(raidHpsPopoutPresenter, raidHpsPopoutMenu, config);

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/main/MainPresenter.java
@@ -344,6 +344,7 @@ public class MainPresenter implements Initializable {
 			final double raidChallengesOpacity, final boolean raidChallengesBars,
 			final double timersOpacity, final boolean timersBars,
 			final double personalOpacity, final boolean personalBars, final String personalMode,
+			final double damageTakenOpacity, final boolean damageTakenBars, final String damageTakenMode,
 			final boolean timersCenter, final Double timersCenterX, final Double timersCenterY,
 			final Integer fractions,
 			final boolean popoutSolid) {
@@ -390,6 +391,11 @@ public class MainPresenter implements Initializable {
 						sp.presenter.setOpacity(personalOpacity);
 						sp.presenter.setBars(personalBars);
 						sp.presenter.setMode(personalMode);
+
+					}else if (sp.presenter instanceof DamageTakenPopoutPresenter) {
+						sp.presenter.setOpacity(damageTakenOpacity);
+						sp.presenter.setBars(damageTakenBars);
+						sp.presenter.setMode(damageTakenMode);
 
 					} else if (sp.presenter instanceof RaidNotesPopoutPresenter) {
 						sp.presenter.setOpacity(personalOpacity); // TODO
@@ -1241,6 +1247,7 @@ public class MainPresenter implements Initializable {
 				final double raidChallengesOpacity, final boolean raidChallengesBars,
 				final double timersOpacity, final boolean timersBars,
 				final double personalOpacity, final boolean personalBars, final String personalMode,
+				final double damageTakenOpacity, final boolean damageTakenBars, final String damageTakenMode,
 				final boolean timersCenter, final Double timersCenterX, final Double timersCenterY,
 				final Integer fractions,
 				final boolean popoutSolid) {
@@ -1251,6 +1258,7 @@ public class MainPresenter implements Initializable {
 					raidChallengesOpacity, raidChallengesBars,
 					timersOpacity, timersBars,
 					personalOpacity, personalBars, personalMode,
+					damageTakenOpacity, damageTakenBars, damageTakenMode,
 					timersCenter, timersCenterX, timersCenterY,
 					fractions,
 					popoutSolid);

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
@@ -152,12 +152,12 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 		absorbedOthersPercent.setText(Format.formatFloat(mitiStats.getAbsorbedOthersPercent()) + " %");
 		absorbedOthers.setText(Format.formatMillions(mitiStats.getAbsorbedOthers()));
 
-		String[] damageTexts1 = getDamageTexts(combat, stats, 1000);
+		String[] damageTexts1 = getDamageTexts(combat, stats, 2000);
 		ieInstant1.setText(damageTexts1[0]);
 		keInstant1.setText(damageTexts1[1]);
 		ftInstant1.setText(damageTexts1[2]);
 		mrInstant1.setText(damageTexts1[3]);
-		String[] damageTexts5 = getDamageTexts(combat, stats, 5000);
+		String[] damageTexts5 = getDamageTexts(combat, stats, 10000);
 		ieInstant5.setText(damageTexts5[0]);
 		keInstant5.setText(damageTexts5[1]);
 		ftInstant5.setText(damageTexts5[2]);

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
@@ -37,10 +37,15 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 	private Label ieInstant1, ieInstant5, keInstant1, keInstant5, ftInstant1, ftInstant5, mrInstant1, mrInstant5;
 
 	@FXML
+	private Label delay1, delay2;
+
+	@FXML
 	private GridPane modeAll, modeInstant;
 
 	@FXML
 	private AnchorPane statsWrapper;
+
+	private Integer dtDelay1 = 2, dtDelay2 = 10;
 
 	protected RaidPresenter raidPresenter;
 
@@ -55,8 +60,8 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 		this.offsetY = 790;
 		this.height = 211;
 
-		addMode(new Mode(Mode.DEFAULT, "Damage Taken Total", 211, modeAll));
-		addMode(new Mode(Mode.DEFAULT, "Damage Taken Instant", 122, modeInstant));
+		addMode(new Mode(Mode.DEFAULT, "Total Taken", 211, modeAll));
+		addMode(new Mode(Mode.DEFAULT, "Currently Taken", 122, modeInstant));
 	}
 
 	public static CombatSelection computeSelectionForPastMillis(final Combat combat, final CombatStats stats, int millisDelay) throws Exception {
@@ -152,12 +157,12 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 		absorbedOthersPercent.setText(Format.formatFloat(mitiStats.getAbsorbedOthersPercent()) + " %");
 		absorbedOthers.setText(Format.formatMillions(mitiStats.getAbsorbedOthers()));
 
-		String[] damageTexts1 = getDamageTexts(combat, stats, 2000);
+		String[] damageTexts1 = getDamageTexts(combat, stats, dtDelay1 == null ? 2000 : dtDelay1 * 1000);
 		ieInstant1.setText(damageTexts1[0]);
 		keInstant1.setText(damageTexts1[1]);
 		ftInstant1.setText(damageTexts1[2]);
 		mrInstant1.setText(damageTexts1[3]);
-		String[] damageTexts5 = getDamageTexts(combat, stats, 10000);
+		String[] damageTexts5 = getDamageTexts(combat, stats, dtDelay2 == null ? 10000 : dtDelay2 * 1000);
 		ieInstant5.setText(damageTexts5[0]);
 		keInstant5.setText(damageTexts5[1]);
 		ftInstant5.setText(damageTexts5[2]);
@@ -170,6 +175,9 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 
 	@Override
 	public void resetCombatStats() {
+		delay1.setText("last "+dtDelay1+"s");
+		delay2.setText("last "+dtDelay2+"s");
+
 		ie.setText("");
 		iePercent.setText("");
 
@@ -233,4 +241,18 @@ public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
 		statsWrapper.setPrefHeight(height - 20);
 		super.setHeight(height);
 	}
+
+    public void setDtDelay1(Integer dtDelay1) {
+		if (dtDelay1 != null) {
+			this.dtDelay1 = dtDelay1;
+			this.delay1.setText("last "+dtDelay1+"s");
+		}
+    }
+
+    public void setDtDelay2(Integer dtDelay2) {
+		if (dtDelay2 != null) {
+			this.dtDelay2 = dtDelay2;
+			this.delay2.setText("last "+dtDelay2+"s");
+		}
+    }
 }

--- a/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
+++ b/starparse-client/src/main/java/com/ixale/starparse/gui/popout/DamageTakenPopoutPresenter.java
@@ -1,0 +1,178 @@
+package com.ixale.starparse.gui.popout;
+
+import com.ixale.starparse.domain.Combat;
+import com.ixale.starparse.domain.CombatChallenge;
+import com.ixale.starparse.domain.ValueType;
+import com.ixale.starparse.domain.stats.*;
+import com.ixale.starparse.gui.Format;
+import com.ixale.starparse.gui.main.RaidPresenter;
+import javafx.fxml.FXML;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Text;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ResourceBundle;
+
+public class DamageTakenPopoutPresenter extends BasePopoutPresenter {
+
+	private static final String MODE_DAMAGE = "damage", MODE_HEALING = "healing";
+
+	@FXML
+	private VBox statsGrid;
+
+	// FIXME: duplicates DamageTakenPresenter
+	@FXML
+	private Label
+			ie, iePercent, ke, kePercent, ft, ftPercent, mr, mrPercent,
+			mt, missPercent, st, shieldPercent,
+			absorbedSelf, absorbedSelfPercent, absorbedOthers, absorbedOthersPercent;
+
+	@FXML
+	private GridPane modeAll;
+
+	@FXML
+	private AnchorPane statsWrapper;
+
+	protected RaidPresenter raidPresenter;
+
+	public void setRaidPresenter(final RaidPresenter raidPresenter) {
+		this.raidPresenter = raidPresenter;
+	}
+
+	@Override
+	public void initialize(URL url, ResourceBundle resourceBundle) {
+		super.initialize(url, resourceBundle);
+
+		this.offsetY = 790;
+		this.height = 211;
+
+		addMode(new Mode(Mode.DEFAULT, "Personal", 211, modeAll));
+	}
+
+	@Override
+	protected void refreshCombatStats(final Combat combat, final CombatStats stats) throws Exception {
+
+		if (combat == null) {
+			return;
+		}
+
+		// mitigation overview
+		final CombatMitigationStats mitiStats = eventService.getCombatMitigationStats(combat, context.getCombatSelection());
+
+		if (mitiStats == null) {
+			// combat gone away
+			resetCombatStats();
+			return;
+		}
+
+		ie.setText(Format.formatMillions(mitiStats.getInternal() + mitiStats.getElemental()));
+		iePercent.setText(Format.formatFloat(mitiStats.getInternalPercent() + mitiStats.getElementalPercent()) + " %");
+		ke.setText(Format.formatMillions(mitiStats.getEnergy() + mitiStats.getKinetic()));
+		kePercent.setText(Format.formatFloat(mitiStats.getEnergyPercent() + mitiStats.getKineticPercent()) + " %");
+
+
+		// FIXME: database
+		int ftTotal = 0, mrTotal = 0, total = 0;
+		List<DamageTakenStats> dtStats = eventService.getDamageTakenStats(combat,
+				false, false, true,
+				context.getCombatSelection());
+		for (final DamageTakenStats dts: dtStats) {
+			total += dts.getTotal();
+			if (dts.getGuid() > 0 && context.getAttacks().containsKey(dts.getGuid())) {
+				switch (context.getAttacks().get(dts.getGuid())) {
+					case FT:
+						ftTotal += dts.getTotal();
+						break;
+					case MR:
+						ftTotal += dts.getTotalIe();
+						mrTotal += dts.getTotal() - dts.getTotalIe();
+						break;
+				}
+			} else {
+				ftTotal += dts.getTotalIe();
+			}
+		}
+		ft.setText(Format.formatMillions(ftTotal));
+		ftPercent.setText(Format.formatFloat(total > 0 ? (ftTotal * 100.0 / total) : 0) + " %");
+		mr.setText(Format.formatMillions(mrTotal));
+		mrPercent.setText(Format.formatFloat(total > 0 ? (mrTotal * 100.0 / total) : 0) + " %");
+
+		mt.setText(Format.formatNumber(mitiStats.getMissTicks()));
+		st.setText(Format.formatNumber(mitiStats.getShieldTicks()));
+		missPercent.setText(Format.formatFloat(mitiStats.getMissPercent()) + " %");
+		shieldPercent.setText(Format.formatFloat(mitiStats.getShieldPercent()) + " %");
+
+		absorbedSelfPercent.setText(Format.formatFloat(mitiStats.getAbsorbedSelfPercent()) + " %");
+		absorbedSelf.setText(Format.formatMillions(mitiStats.getAbsorbedSelf()));
+		absorbedOthersPercent.setText(Format.formatFloat(mitiStats.getAbsorbedOthersPercent()) + " %");
+		absorbedOthers.setText(Format.formatMillions(mitiStats.getAbsorbedOthers()));
+	}
+
+
+
+
+
+	@Override
+	public void resetCombatStats() {
+		ie.setText("");
+		iePercent.setText("");
+
+		ke.setText("");
+		kePercent.setText("");
+
+		ft.setText("");
+		ftPercent.setText("");
+		mr.setText("");
+		mrPercent.setText("");
+
+		missPercent.setText("");
+		mt.setText("");
+		shieldPercent.setText("");
+		st.setText("");
+
+		absorbedSelfPercent.setText("");
+		absorbedSelf.setText("");
+
+		absorbedOthers.setText("");
+		absorbedOthersPercent.setText("");
+	}
+
+	@Override
+	public void setTextColor(Color color) {
+		super.setTextColor(color);
+
+		setLabelColor(color);
+	}
+
+	private void setLabelColor(Color color) {
+		for (Mode m: getModes()) {
+			for (final Node n: ((GridPane) m.wrapper).getChildren()) {
+				if (n instanceof Text) {
+					((Text) n).setFill(color);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void repaint(Object source) {
+		super.repaint(source);
+		setLabelColor(textColor);
+	}
+
+	@Override
+	protected void setHeight(int height) {
+		statsWrapper.setPrefHeight(height - 20);
+		super.setHeight(height);
+	}
+}

--- a/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
+++ b/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
@@ -29,7 +29,7 @@
         <Rectangle fx:id="popoutBackground" fill="BLACK" height="191.0" opacity="0.7" width="150.0" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0" />
         <VBox fx:id="statsGrid" alignment="TOP_LEFT" layoutX="0.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" opacity="1.0" prefHeight="191.0" prefWidth="150.0" spacing="0.5" AnchorPane.topAnchor="0.0">
           <children>
-            <GridPane fx:id="modeAll" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="171.0" prefWidth="150.0" styleClass="combat-stats" vgap="2.0" VBox.vgrow="NEVER">
+            <GridPane fx:id="modeAll" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="171.0" prefWidth="150.0" styleClass="damage-taken" vgap="2.0" VBox.vgrow="NEVER">
               <children>
                 <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="0" />
                 <Text text="K/E" GridPane.columnIndex="0" GridPane.rowIndex="1" />
@@ -40,22 +40,22 @@
                 <Text text="Abs" GridPane.columnIndex="0" GridPane.rowIndex="6" />
                 <Text text="Abg" GridPane.columnIndex="0" GridPane.rowIndex="7" />
 <!--                <Text text="Abs" GridPane.columnIndex="0" GridPane.rowIndex="8" />-->
-                <Label fx:id="iePercent" styleClass="apm" text="46.35" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
-                <Label fx:id="ie" styleClass="apm" text="07:35" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
-                <Label fx:id="kePercent" styleClass="damage2, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
-                <Label fx:id="ke" styleClass="damage2" text="3 654 321" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
-                <Label fx:id="ftPercent" styleClass="healing, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
-                <Label fx:id="ft" styleClass="healing" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
-                <Label fx:id="mrPercent" styleClass="healing-eff, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
-                <Label fx:id="mr" styleClass="healing-eff" text="67 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
-                <Label fx:id="missPercent" styleClass="threat, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
-                <Label fx:id="mt" styleClass="threat" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
-                <Label fx:id="shieldPercent" styleClass="damage2, taken, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
-                <Label fx:id="st" styleClass="damage2, taken" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
-                <Label fx:id="absorbedSelfPercent" styleClass="absorbed, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
-                <Label fx:id="absorbedSelf" styleClass="absorbed" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
-                <Label fx:id="absorbedOthersPercent" styleClass="healing, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
-                <Label fx:id="absorbedOthers" styleClass="healing" text="54 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
+                <Label fx:id="iePercent" styleClass="ie, pc" text="46.35" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
+                <Label fx:id="ie" styleClass="ie" text="07:35" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
+                <Label fx:id="kePercent" styleClass="ke, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="ke" styleClass="ke" text="3 654 321" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="ftPercent" styleClass="ft, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="ft" styleClass="ft" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="mrPercent" styleClass="mr, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="mr" styleClass="mr" text="67 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="missPercent" styleClass="avd, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                <Label fx:id="mt" styleClass="avd" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                <Label fx:id="shieldPercent" styleClass="shd, taken, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
+                <Label fx:id="st" styleClass="shd, taken" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
+                <Label fx:id="absorbedSelfPercent" styleClass="abs, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
+                <Label fx:id="absorbedSelf" styleClass="abs" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
+                <Label fx:id="absorbedOthersPercent" styleClass="abg, pc" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
+                <Label fx:id="absorbedOthers" styleClass="abg" text="54 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
 <!--                <Label fx:id="aps" styleClass="absorbed, taken, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="8" />-->
 <!--                <Label fx:id="absorbed" styleClass="absorbed, taken" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="8" />-->
               </children>

--- a/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
+++ b/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
@@ -32,8 +32,8 @@
             <GridPane fx:id="modeInstant" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="105.0" prefWidth="150.0" styleClass="damage-taken" vgap="2.0" visible="true" VBox.vgrow="NEVER">
               <children>
                 <Text text="  " GridPane.columnIndex="0" GridPane.rowIndex="0" />
-                <Text text="last 5s" GridPane.columnIndex="1" GridPane.rowIndex="0" />
-                <Text text="last 1s" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                <Text text="last 10s" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                <Text text="last 2s" GridPane.columnIndex="2" GridPane.rowIndex="0" />
                 <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="1" />
                 <Text text="K/E" GridPane.columnIndex="0" GridPane.rowIndex="2" />
                 <Text text="F/T" GridPane.columnIndex="0" GridPane.rowIndex="3" />

--- a/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
+++ b/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
@@ -29,6 +29,37 @@
         <Rectangle fx:id="popoutBackground" fill="BLACK" height="191.0" opacity="0.7" width="150.0" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0" />
         <VBox fx:id="statsGrid" alignment="TOP_LEFT" layoutX="0.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" opacity="1.0" prefHeight="191.0" prefWidth="150.0" spacing="0.5" AnchorPane.topAnchor="0.0">
           <children>
+            <GridPane fx:id="modeInstant" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="105.0" prefWidth="150.0" styleClass="damage-taken" vgap="2.0" visible="true" VBox.vgrow="NEVER">
+              <children>
+                <Text text="  " GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                <Text text="last 5s" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                <Text text="last 1s" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="1" />
+                <Text text="K/E" GridPane.columnIndex="0" GridPane.rowIndex="2" />
+                <Text text="F/T" GridPane.columnIndex="0" GridPane.rowIndex="3" />
+                <Text text="M/R" GridPane.columnIndex="0" GridPane.rowIndex="4" />
+                <Label fx:id="ieInstant1" styleClass="ie, ps" text="46.35" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="ieInstant5" styleClass="ie" text="07:35" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="keInstant1" styleClass="ke, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="keInstant5" styleClass="ke" text="3 654 321" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="ftInstant1" styleClass="ft, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="ftInstant5" styleClass="ft" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="mrInstant1" styleClass="mr, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                <Label fx:id="mrInstant5" styleClass="mr" text="67 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+              </children>
+              <columnConstraints>
+                <ColumnConstraints hgrow="NEVER" minWidth="-Infinity" prefWidth="30.0"  />
+                <ColumnConstraints hgrow="NEVER" minWidth="-Infinity" prefWidth="45.0" halignment="CENTER" />
+                <ColumnConstraints hgrow="NEVER" minWidth="-Infinity" prefWidth="45.0" halignment="CENTER" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="12.0" valignment="BOTTOM" vgrow="NEVER" />
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="18.0" valignment="BOTTOM" vgrow="NEVER" />
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="18.0" valignment="BOTTOM" vgrow="NEVER" />
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="18.0" valignment="BOTTOM" vgrow="NEVER" />
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="18.0" valignment="BOTTOM" vgrow="NEVER" />
+              </rowConstraints>
+            </GridPane>
             <GridPane fx:id="modeAll" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="171.0" prefWidth="150.0" styleClass="damage-taken" vgap="2.0" VBox.vgrow="NEVER">
               <children>
                 <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="0" />

--- a/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
+++ b/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.net.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.chart.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.paint.*?>
+<?import javafx.scene.shape.*?>
+<?import javafx.scene.text.*?>
+<?scenebuilder-stylesheet ../popouts.css?>
+
+<VBox fx:id="popoutRoot" disable="false" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="211.0" prefWidth="300.0" spacing="0.0" styleClass="popout" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/2.2" fx:controller="com.ixale.starparse.gui.popout.DamageTakenPopoutPresenter">
+  <children>
+    <AnchorPane minHeight="-1.0" prefHeight="-1.0" prefWidth="-1.0" scaleX="1.0" scaleY="1.0" styleClass="popout-header" VBox.vgrow="NEVER">
+      <children>
+        <Rectangle fx:id="popoutTitleBackground" fill="BLACK" height="19.0" opacity="0.9" width="150.0" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0" />
+        <Label fx:id="popoutTitle" alignment="CENTER" minHeight="-Infinity" prefHeight="19.0" styleClass="popout-title" text="Damage Taken" textAlignment="CENTER" underline="false" wrapText="false" AnchorPane.leftAnchor="25.0" AnchorPane.topAnchor="0.0" />
+        <Button focusTraversable="false" onAction="#handleIncreaseOpacity" text="+" AnchorPane.leftAnchor="2.0" AnchorPane.topAnchor="2.0" />
+        <Button focusTraversable="false" onAction="#handleDecreaseOpacity" text="-" AnchorPane.leftAnchor="14.0" AnchorPane.topAnchor="2.0" />
+        <Button focusTraversable="false" onAction="#handleToggleMode" text="M" AnchorPane.leftAnchor="110.0" AnchorPane.topAnchor="2.0" />
+        <Button focusTraversable="false" onAction="#handleToggleBars" text="B" AnchorPane.leftAnchor="125.0" AnchorPane.topAnchor="2.0" />
+        <Button focusTraversable="false" onAction="#handleClose" text="X" AnchorPane.leftAnchor="137.0" AnchorPane.topAnchor="2.0" />
+      </children>
+    </AnchorPane>
+    <AnchorPane fx:id="statsWrapper" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="191.0" prefWidth="150.0" VBox.vgrow="NEVER">
+      <children>
+        <Rectangle fx:id="popoutBackground" fill="BLACK" height="191.0" opacity="0.7" width="150.0" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0" />
+        <VBox fx:id="statsGrid" alignment="TOP_LEFT" layoutX="0.0" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" opacity="1.0" prefHeight="191.0" prefWidth="150.0" spacing="0.5" AnchorPane.topAnchor="0.0">
+          <children>
+            <GridPane fx:id="modeAll" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="171.0" prefWidth="150.0" styleClass="combat-stats" vgap="2.0" VBox.vgrow="NEVER">
+              <children>
+                <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                <Text text="K/E" GridPane.columnIndex="0" GridPane.rowIndex="1" />
+                <Text text="F/T" GridPane.columnIndex="0" GridPane.rowIndex="2" />
+                <Text text="M/R" GridPane.columnIndex="0" GridPane.rowIndex="3" />
+                <Text text="Avd" GridPane.columnIndex="0" GridPane.rowIndex="4" />
+                <Text text="Shd" GridPane.columnIndex="0" GridPane.rowIndex="5" />
+                <Text text="Abs" GridPane.columnIndex="0" GridPane.rowIndex="6" />
+                <Text text="Abg" GridPane.columnIndex="0" GridPane.rowIndex="7" />
+<!--                <Text text="Abs" GridPane.columnIndex="0" GridPane.rowIndex="8" />-->
+                <Label fx:id="iePercent" styleClass="apm" text="46.35" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
+                <Label fx:id="ie" styleClass="apm" text="07:35" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="0" />
+                <Label fx:id="kePercent" styleClass="damage2, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="ke" styleClass="damage2" text="3 654 321" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+                <Label fx:id="ftPercent" styleClass="healing, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="ft" styleClass="healing" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                <Label fx:id="mrPercent" styleClass="healing-eff, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="mr" styleClass="healing-eff" text="67 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="3" />
+                <Label fx:id="missPercent" styleClass="threat, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                <Label fx:id="mt" styleClass="threat" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                <Label fx:id="shieldPercent" styleClass="damage2, taken, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
+                <Label fx:id="st" styleClass="damage2, taken" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
+                <Label fx:id="absorbedSelfPercent" styleClass="absorbed, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
+                <Label fx:id="absorbedSelf" styleClass="absorbed" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
+                <Label fx:id="absorbedOthersPercent" styleClass="healing, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
+                <Label fx:id="absorbedOthers" styleClass="healing" text="54 %" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="7" />
+<!--                <Label fx:id="aps" styleClass="absorbed, taken, ps" text="3 654" GridPane.columnIndex="2" GridPane.halignment="RIGHT" GridPane.rowIndex="8" />-->
+<!--                <Label fx:id="absorbed" styleClass="absorbed, taken" text="3 654" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="8" />-->
+              </children>
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="-1.0" prefWidth="-1.0" />
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" prefWidth="55.0" />
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" prefWidth="35.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints fillHeight="false" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="15.0" valignment="BOTTOM" vgrow="NEVER" />
+                <RowConstraints maxHeight="-1.0" minHeight="20.0" prefHeight="-1.0" valignment="BOTTOM" vgrow="SOMETIMES" />
+                <RowConstraints maxHeight="-1.0" minHeight="-1.0" prefHeight="-1.0" vgrow="SOMETIMES" />
+                <RowConstraints maxHeight="-1.0" minHeight="-1.0" prefHeight="-1.0" vgrow="SOMETIMES" />
+                <RowConstraints maxHeight="-1.0" minHeight="-1.0" prefHeight="-1.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="20.0" valignment="BOTTOM" />
+              </rowConstraints>
+            </GridPane>
+          </children>
+          <padding>
+            <Insets top="1.0" />
+          </padding>
+        </VBox>
+        <AnchorPane fx:id="popoutFooter" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="19.0" prefWidth="-1.0" styleClass="popout-footer" visible="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+          <children>
+            <Rectangle height="19.0" opacity="0.5" width="150.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" />
+            <Rectangle fx:id="resizeSW" fill="TRANSPARENT" height="18.0" opacity="0.5" width="18.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" />
+            <Rectangle fx:id="resizeSE" fill="TRANSPARENT" height="18.0" opacity="0.5" width="18.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="132.0" />
+            <Line disable="true" endX="10.0" endY="-10.0" fill="TRANSPARENT" rotate="0.0" startX="0.0" startY="0.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="138.0">
+              <stroke>
+                <Color blue="0.376" green="0.376" red="0.376" fx:id="x1" />
+              </stroke>
+            </Line>
+            <Line disable="true" endX="5.0" endY="-5.0" rotate="0.0" startX="0.0" startY="0.0" stroke="$x1" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="143.0" />
+            <Line disable="true" endX="-10.0" endY="-10.0" rotate="0.0" startX="0.0" startY="0.0" stroke="$x1" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" />
+            <Line disable="true" endX="-5.0" endY="-5.0" rotate="0.0" startX="0.0" startY="0.0" stroke="$x1" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" />
+          </children>
+        </AnchorPane>
+      </children>
+      <VBox.margin>
+        <Insets top="1.0" />
+      </VBox.margin>
+    </AnchorPane>
+  </children>
+</VBox>

--- a/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
+++ b/starparse-client/src/main/resources/fxml/DamageTakenPopout.fxml
@@ -32,8 +32,8 @@
             <GridPane fx:id="modeInstant" alignment="TOP_LEFT" hgap="0.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="105.0" prefWidth="150.0" styleClass="damage-taken" vgap="2.0" visible="true" VBox.vgrow="NEVER">
               <children>
                 <Text text="  " GridPane.columnIndex="0" GridPane.rowIndex="0" />
-                <Text text="last 10s" GridPane.columnIndex="1" GridPane.rowIndex="0" />
-                <Text text="last 2s" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                <Label fx:id="delay2" styleClass="white" text="last 10s" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                <Label fx:id="delay1" styleClass="white" text="last 2s" GridPane.columnIndex="2" GridPane.rowIndex="0" />
                 <Text text="I/E" GridPane.columnIndex="0" GridPane.rowIndex="1" />
                 <Text text="K/E" GridPane.columnIndex="0" GridPane.rowIndex="2" />
                 <Text text="F/T" GridPane.columnIndex="0" GridPane.rowIndex="3" />

--- a/starparse-client/src/main/resources/fxml/Main.fxml
+++ b/starparse-client/src/main/resources/fxml/Main.fxml
@@ -186,6 +186,7 @@
             <Menu mnemonicParsing="false" text="Interface">
               <items>
                 <CheckMenuItem fx:id="personalStatsPopoutMenu" mnemonicParsing="false" onAction="#handlePopoutToggle" text="Personal Stats" />
+                <CheckMenuItem fx:id="damageTakenPopoutMenu" mnemonicParsing="false" onAction="#handlePopoutToggle" text="Damage Taken" />
                 <CheckMenuItem fx:id="timersPopoutMenu" mnemonicParsing="false" onAction="#handlePopoutToggle" text="Combat Timers" />
                 <CheckMenuItem fx:id="timersCenterPopoutMenu" mnemonicParsing="false" onAction="#handlePopoutToggle" text="Timers Center" visible="false" />
                 <SeparatorMenuItem mnemonicParsing="false" text="" />

--- a/starparse-client/src/main/resources/fxml/SettingsDialog.fxml
+++ b/starparse-client/src/main/resources/fxml/SettingsDialog.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.text.*?>
 <?scenebuilder-stylesheet ../styles.css?>
 
-<TabPane fx:id="dialogRoot" maxHeight="-Infinity" minHeight="-Infinity" minWidth="520.0" prefHeight="330.0" styleClass="modal-text" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.ixale.starparse.gui.dialog.SettingsDialogPresenter">
+<TabPane fx:id="dialogRoot" maxHeight="-Infinity" minHeight="-Infinity" minWidth="520.0" prefHeight="350.0" styleClass="modal-text" tabClosingPolicy="UNAVAILABLE" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.ixale.starparse.gui.dialog.SettingsDialogPresenter">
   <tabs>
     <Tab fx:id="contentGeneral" text="General">
       <content>
@@ -260,6 +260,11 @@
                 <TextField fx:id="personalOpacityText" alignment="CENTER_RIGHT" disable="false" editable="true" maxWidth="-Infinity" prefWidth="30.0" text="70" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
                 <CheckBox fx:id="personalBars" selected="true" text="Bars" GridPane.columnIndex="2" GridPane.rowIndex="5" />
                 <ChoiceBox fx:id="personalMode" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="100.0" GridPane.columnIndex="3" GridPane.rowIndex="5" />
+                <Label text="Damage Taken" GridPane.columnIndex="0" GridPane.rowIndex="6" />
+                <Slider fx:id="damageTakenOpacitySlider" blockIncrement="10.0" majorTickUnit="1.0" maxWidth="-Infinity" min="1.0" minHeight="-1.0" minWidth="-Infinity" minorTickCount="0" orientation="HORIZONTAL" prefWidth="60.0" showTickLabels="false" showTickMarks="false" snapToTicks="true" value="70.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                <TextField fx:id="damageTakenOpacityText" alignment="CENTER_RIGHT" disable="false" editable="true" maxWidth="-Infinity" prefWidth="30.0" text="70" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
+                <CheckBox fx:id="damageTakenBars" selected="true" text="Bars" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+                <ChoiceBox fx:id="damageTakenMode" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="125.0" GridPane.columnIndex="3" GridPane.rowIndex="6" />
               </children>
               <columnConstraints>
                 <ColumnConstraints fillWidth="false" hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity" percentWidth="-1.0" prefWidth="70.0" />

--- a/starparse-client/src/main/resources/fxml/SettingsDialog.fxml
+++ b/starparse-client/src/main/resources/fxml/SettingsDialog.fxml
@@ -264,7 +264,23 @@
                 <Slider fx:id="damageTakenOpacitySlider" blockIncrement="10.0" majorTickUnit="1.0" maxWidth="-Infinity" min="1.0" minHeight="-1.0" minWidth="-Infinity" minorTickCount="0" orientation="HORIZONTAL" prefWidth="60.0" showTickLabels="false" showTickMarks="false" snapToTicks="true" value="70.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                 <TextField fx:id="damageTakenOpacityText" alignment="CENTER_RIGHT" disable="false" editable="true" maxWidth="-Infinity" prefWidth="30.0" text="70" GridPane.columnIndex="1" GridPane.halignment="RIGHT" GridPane.rowIndex="6" />
                 <CheckBox fx:id="damageTakenBars" selected="true" text="Bars" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-                <ChoiceBox fx:id="damageTakenMode" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="125.0" GridPane.columnIndex="3" GridPane.rowIndex="6" />
+                <ChoiceBox fx:id="damageTakenMode" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="100.0" GridPane.columnIndex="3" GridPane.rowIndex="6" />
+                <GridPane maxHeight="-Infinity" minHeight="-Infinity" prefHeight="-1.0" VBox.vgrow="NEVER" GridPane.columnIndex="4" GridPane.rowIndex="6">
+                  <children>
+                    <Label text="Delay 1" GridPane.columnIndex="0" GridPane.rowIndex="0" />
+                    <TextField fx:id="dtDelay1" alignment="CENTER_RIGHT" disable="false" editable="true" maxWidth="-Infinity" prefWidth="20.0" promptText="s" GridPane.columnIndex="1" GridPane.rowIndex="0">
+                      <GridPane.margin>
+                        <Insets right="10.0" />
+                      </GridPane.margin>
+                    </TextField>
+                    <Label text="Delay 2" GridPane.columnIndex="2" GridPane.rowIndex="0" />
+                    <TextField fx:id="dtDelay2" alignment="CENTER_RIGHT" disable="false" editable="true" maxWidth="-Infinity" prefWidth="20.0" promptText="s" GridPane.columnIndex="3" GridPane.halignment="RIGHT" GridPane.rowIndex="0">
+                      <GridPane.margin>
+                        <Insets right="10.0" />
+                      </GridPane.margin>
+                    </TextField>
+                  </children>
+                </GridPane>
               </children>
               <columnConstraints>
                 <ColumnConstraints fillWidth="false" hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity" percentWidth="-1.0" prefWidth="70.0" />

--- a/starparse-client/src/main/resources/popouts.css
+++ b/starparse-client/src/main/resources/popouts.css
@@ -33,6 +33,10 @@
     -fx-font-weight: bold;
 }
 
+.damage-taken .ps {
+    -fx-font-weight: bold;
+}
+
 .combat-stats .damage {
 	-fx-text-fill: maroon;
 }
@@ -77,4 +81,43 @@
 	-fx-stroke: black;
     -fx-stroke-width: 1px;
     -fx-stroke-type: outside;
+}
+
+.damage-taken .ie {
+	-fx-text-fill: #b22222;
+}
+
+
+.damage-taken .ke {
+	-fx-text-fill: #7e481c;
+}
+
+
+.damage-taken .ft {
+	-fx-text-fill: #fada5e;
+}
+
+
+.damage-taken .mr {
+	-fx-text-fill: #ded8c9;
+}
+
+
+.damage-taken .avd {
+	-fx-text-fill: #cc8899;
+}
+
+
+.damage-taken .shd {
+	-fx-text-fill: #009ca6;
+}
+
+
+.damage-taken .abs {
+	-fx-text-fill: #30cccd;
+}
+
+
+.damage-taken .abg {
+	-fx-text-fill: #3f7aff;
 }

--- a/starparse-client/src/main/resources/popouts.css
+++ b/starparse-client/src/main/resources/popouts.css
@@ -97,6 +97,10 @@
 	-fx-text-fill: #fada5e;
 }
 
+.damage-taken .white {
+	-fx-text-fill: white;
+}
+
 
 .damage-taken .mr {
 	-fx-text-fill: #ded8c9;

--- a/starparse-client/src/main/resources/popouts.css
+++ b/starparse-client/src/main/resources/popouts.css
@@ -89,7 +89,7 @@
 
 
 .damage-taken .ke {
-	-fx-text-fill: #7e481c;
+	-fx-text-fill: #a55200;
 }
 
 


### PR DESCRIPTION
This PR adds a Damage Taken Popout to StarParse. The goal is to help tank find the correct defensive skill to use at each moment of the fight.

![image](https://user-images.githubusercontent.com/82438209/115150720-e9d51c00-a069-11eb-9910-297eb449cbdb.png)

The setting menu has been updated accordingly

![image](https://user-images.githubusercontent.com/82438209/115150760-1ab55100-a06a-11eb-8ba2-2eb6e5776514.png)

Note that there is another mode to the new overlay, that displays overall tanking stats as in Damage Taken tab from star parse

![image](https://user-images.githubusercontent.com/82438209/115150805-4e907680-a06a-11eb-88a1-d07c3534333b.png)



Note that I developed in a JDK 11 environment. I don't think I used anything specific to JDK 11 in my code so I cherry picked all the commits to a branch which starts from master. SInce I was unable to test it I don't know if it will work in JDK8. But at least it should be ok in JDK11 (see my other PR)